### PR TITLE
Updates for pytorch 1.7 compatibility

### DIFF
--- a/src/bvh.cpp
+++ b/src/bvh.cpp
@@ -22,8 +22,8 @@
 void bvh_cuda_forward(at::Tensor triangles, at::Tensor* collision_tensor_ptr,
         int max_collisions = 16);
 
-#define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
-#define CHECK_CONTIGUOUS(x) AT_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_CUDA(x) TORCH_CHECK(x.is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
 
 at::Tensor bvh_forward(at::Tensor triangles, int max_collisions = 16) {


### PR DESCRIPTION
These changes were required for successful compilation with pytorch '1.7.0a0+7036e91'.

I also ran into the same problem as #24 , not sure why since [CUDAExtension](https://pytorch.org/docs/stable/_modules/torch/utils/cpp_extension.html#CUDAExtension) still does take the `include_dirs` argument.